### PR TITLE
Revert pagerduty success alerts

### DIFF
--- a/awslimitchecker/alerts/base.py
+++ b/awslimitchecker/alerts/base.py
@@ -59,20 +59,18 @@ class AlertProvider(object):
         :type region_name: str
         """
         self._region_name = region_name
-
-    ### Disable Alerting on Success
     
-    # @abstractmethod
-    # def on_success(self, duration=None):
-    #     """
-    #     Method called when no thresholds were breached, and run completed
-    #     successfully. Should resolve any open incidents (if the service supports
-    #     that functionality) or else simply return.
+    @abstractmethod
+    def on_success(self, duration=None):
+        """
+        Method called when no thresholds were breached, and run completed
+        successfully. Should resolve any open incidents (if the service supports
+        that functionality) or else simply return.
 
-    #     :param duration: duration of the usage/threshold checking run
-    #     :type duration: float
-    #     """
-    #     raise NotImplementedError()
+        :param duration: duration of the usage/threshold checking run
+        :type duration: float
+        """
+        raise NotImplementedError()
 
     @abstractmethod
     def on_critical(self, problems, problem_str, exc=None, duration=None):

--- a/awslimitchecker/alerts/dummy.py
+++ b/awslimitchecker/alerts/dummy.py
@@ -61,21 +61,19 @@ class Dummy(AlertProvider):
         :type region_name: str
         """
         super(Dummy, self).__init__(region_name)
-
-    ### Disable Alerting on Success
     
-    # def on_success(self, duration=None):
-    #     """
-    #     Method called when no thresholds were breached, and run completed
-    #     successfully. Should resolve any open incidents (if the service supports
-    #     that functionality) or else simply return.
+    def on_success(self, duration=None):
+        """
+        Method called when no thresholds were breached, and run completed
+        successfully. Should resolve any open incidents (if the service supports
+        that functionality) or else simply return.
 
-    #     :param duration: duration of the usage/threshold checking run
-    #     :type duration: float
-    #     """
-    #     print('awslimitchecker in %s found no problems' % self._region_name)
-    #     if duration:
-    #         print('awslimitchecker run duration: %s' % duration)
+        :param duration: duration of the usage/threshold checking run
+        :type duration: float
+        """
+        print('awslimitchecker in %s found no problems' % self._region_name)
+        if duration:
+            print('awslimitchecker run duration: %s' % duration)
 
     def on_critical(self, problems, problem_str, exc=None, duration=None):
         """

--- a/awslimitchecker/alerts/pagerdutyv1.py
+++ b/awslimitchecker/alerts/pagerdutyv1.py
@@ -163,35 +163,34 @@ class PagerDutyV1(AlertProvider):
                 },
             },
             'routing_key': os.environ.get('PAGERDUTY_ROUTING_KEY', None),
+            'dedup_key': os.environ.get('PAGERDUTY_ROUTING_KEY', None),
             'incident_key': self._incident_key,
             'client': 'awslimitchecker'
         }
         return d
-
-    ### Disable Alerting on Success
     
-    # def on_success(self, duration=None):
-    #     """
-    #     Method called when no thresholds were breached, and run completed
-    #     successfully. Should resolve any open incidents (if the service supports
-    #     that functionality) or else simply return.
+    def on_success(self, duration=None):
+        """
+        Method called when no thresholds were breached, and run completed
+        successfully. Should resolve any open incidents (if the service supports
+        that functionality) or else simply return.
 
-    #     :param duration: duration of the usage/threshold checking run
-    #     :type duration: float
-    #     """
-    #     data = self._event_dict()
-    #     data['payload']['summary'] = 'AWS Limit Check Success ' + self._account_alias + ' ' + self._region_name
-    #     data['event_action'] = 'resolve'
-    #     data['description'] = 'awslimitchecker in '
-    #     if self._account_alias is not None:
-    #         data['description'] += self._account_alias + ' '
-    #     data['description'] += self._region_name + ' found no problems'
-    #     if duration:
-    #         data['description'] += '; run completed in %.2f seconds' % duration
-    #         data['payload']['custom_details']['duration_seconds'] = duration
-    #     self._send_event(self._service_key_crit, data)
-    #     if self._service_key_warn is not None:
-    #         self._send_event(self._service_key_warn, data)
+        :param duration: duration of the usage/threshold checking run
+        :type duration: float
+        """
+        data = self._event_dict()
+        data['payload']['summary'] = 'AWS Limit Check Success ' + self._account_alias + ' ' + self._region_name
+        data['event_action'] = 'resolve'
+        data['description'] = 'awslimitchecker in '
+        if self._account_alias is not None:
+            data['description'] += self._account_alias + ' '
+        data['description'] += self._region_name + ' found no problems'
+        if duration:
+            data['description'] += '; run completed in %.2f seconds' % duration
+            data['payload']['custom_details']['duration_seconds'] = duration
+        self._send_event(self._service_key_crit, data)
+        if self._service_key_warn is not None:
+            self._send_event(self._service_key_warn, data)
 
     def _problems_dict(self, problems):
         """

--- a/awslimitchecker/runner.py
+++ b/awslimitchecker/runner.py
@@ -538,9 +538,8 @@ class Runner(object):
                 alerter.on_warning(
                     problems, problem_str, duration=time.time() - start_time
                 )
-            ### Disable Alerting on Success
-            # else:
-            #     alerter.on_success(duration=time.time() - start_time)
+            else:
+                alerter.on_success(duration=time.time() - start_time)
             # with alert provider, always exit zero
             raise SystemExit(0)
         raise SystemExit(res)


### PR DESCRIPTION
- Revert disabling of success alerts
- Add `dedup_key` to message payload to resolve PD alerts 